### PR TITLE
Add WebSocket client validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ chrome --remote-debugging-port=9222
    npm start
    ```
 
+   Optionally restrict incoming WebSocket connections by setting
+   `ALLOWED_ORIGIN` to a specific origin or `SHARED_SECRET` to require a
+   token. When using `SHARED_SECRET`, clients must include
+   `?token=<your-token>` in the WebSocket URL.
+
 3. **Open the client**
 
    Navigate to `file:///<path>/xvision_project/public/index.html` in any browser. For full functionality you may need to run a static server (e.g. `npx http-server ./public`).


### PR DESCRIPTION
## Summary
- Validate connecting clients using `ALLOWED_ORIGIN` and `SHARED_SECRET`
- Reject unauthorized WebSocket connections and log attempts
- Document connection security options in README

## Testing
- `npm test` *(fails: Missing script "test")*
- `node server.js` *(fails: connect ECONNREFUSED 127.0.0.1:9222)*

------
https://chatgpt.com/codex/tasks/task_e_68a6be2b3e9083298e42ab2785a756f6