### PR TITLE
feat: retry CDP connection with exponential backoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,13 @@ chrome --remote-debugging-port=9222
 
 4. **Open DevTools in the tab you wish to inspect** and interact with the page. You should see coloured orbits correspond to network requests, with exceptions causing a flash.
 
+### Configuration
+
+The server retries connections to Chrome when an initial attempt fails or a session disconnects. You can tune this behaviour with environment variables:
+
+- `RETRY_INTERVAL_MS` – base delay in milliseconds between retry attempts (default `1000`).
+- `MAX_RETRY_ATTEMPTS` – maximum number of attempts before giving up (default `5`).
+
 ## Next Steps for a Production‑Ready Release
 
 This prototype is a foundation. To achieve a 10/10 on all metrics, consider the following enhancements:


### PR DESCRIPTION
## Summary
- reconnect to Chrome DevTools on connection failures or disconnects with exponential backoff
- allow configuration of retry delay and max attempts
- document new retry options in README

## Testing
- `npm test` (fails: Missing script: "test")
- `RETRY_INTERVAL_MS=10 MAX_RETRY_ATTEMPTS=2 node server.js` (fails to connect and shows retry messages)

------
https://chatgpt.com/codex/tasks/task_e_68a6be2ed2c48329ae258063deb8d5f0