### PR TITLE
Pin dependencies for reproducible builds

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,84 @@
+{
+  "name": "xvision-project",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "xvision-project",
+      "version": "0.1.0",
+      "dependencies": {
+        "chrome-remote-interface": "0.31.1",
+        "three": "0.152.0",
+        "ws": "8.15.1"
+      }
+    },
+    "node_modules/chrome-remote-interface": {
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/chrome-remote-interface/-/chrome-remote-interface-0.31.1.tgz",
+      "integrity": "sha512-cvNTnXfx4kYCaeh2sEKrdlqZsYRleACPL47O8LrrjihVfBQbfPmf03vVqSSm7SIeqyo2P77ZXovrBAs4D/nopQ==",
+      "license": "MIT",
+      "dependencies": {
+        "commander": "2.11.x",
+        "ws": "^7.2.0"
+      },
+      "bin": {
+        "chrome-remote-interface": "bin/client.js"
+      }
+    },
+    "node_modules/chrome-remote-interface/node_modules/ws": {
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/commander": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+      "license": "MIT"
+    },
+    "node_modules/three": {
+      "version": "0.152.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.152.0.tgz",
+      "integrity": "sha512-uvKoYo4b2bnqzsR4RJFuWecxwMKcgT1nFNmiWooCNr6AxZLCtfkj/xcfFgoi5mFopSVorh7bnvTHPfeW8DINGg==",
+      "license": "MIT"
+    },
+    "node_modules/ws": {
+      "version": "8.15.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.15.1.tgz",
+      "integrity": "sha512-W5OZiCjXEmk0yZ66ZN82beM5Sz7l7coYxpRkzS+p9PP+ToQry8szKh+61eNktr7EA9DOwvFGhfC605jDHbP6QQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
     "start": "node server.js"
   },
   "dependencies": {
-    "chrome-remote-interface": "^0.31.1",
-    "ws": "^8.15.1",
-    "three": "^0.152.0"
+    "chrome-remote-interface": "0.31.1",
+    "ws": "8.15.1",
+    "three": "0.152.0"
   },
   "private": true
 }


### PR DESCRIPTION
## Summary
- pin dependency versions in `package.json`
- add autogenerated `package-lock.json` for deterministic installs

## Testing
- `npm install`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a6be2eba5483298dd37c0951aa8d64